### PR TITLE
Add predefined snippets for canonical devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This VSCode extension aims to enhance the development workflow for LinuxCNC user
 ### Enhanced Code Templates and Snippets
 - Component Snippets Based on Examples: Predefined code snippets based on the examples provided in the latest documentation, including a full template for a basic HAL component and snippets for common HAL component patterns.
 - Task Templates for HAL Components: Ready-to-use task templates for compiling and testing HAL components.
+- Predefined Snippets for Canonical Devices: Provide snippets for canonical devices such as step generators, encoders, PWM generators, and DACs. These snippets are based on canonical device usage examples from the documentation.
 
 ### Inline Documentation and Context-Sensitive Help
 - Tooltips and Inline Docs: Tooltips for key HAL directives (e.g., `pin`, `param`, `function`, `option`) based on the most recent documentation.

--- a/package.json
+++ b/package.json
@@ -95,6 +95,12 @@
         "scopeName": "source.comp",
         "path": "./syntaxes/comp.tmLanguage.json"
       }
+    ],
+    "snippets": [
+      {
+        "language": "comp",
+        "path": "./snippets/comp.json"
+      }
     ]
   },
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,31 @@ pin out float my_output_pin "An output pin";
 param rw float my_param "A parameter";
 function _ "Main function";
 license "GPL";
+`,
+        step_generator: `component stepgen "A step generator component";
+pin in float velocity-cmd "Velocity command";
+pin out float position-fb "Position feedback";
+pin out bit enable "Enable signal";
+function _ "Main function";
+license "GPL";
+`,
+        encoder: `component encoder "An encoder component";
+pin out float position-fb "Position feedback";
+pin in float scale "Scale factor";
+function _ "Main function";
+license "GPL";
+`,
+        pwm_generator: `component pwmgen "A PWM generator component";
+pin in float value "PWM value";
+pin out bit enable "Enable signal";
+function _ "Main function";
+license "GPL";
+`,
+        dac: `component dac "A DAC component";
+pin in float value "DAC value";
+pin out bit enable "Enable signal";
+function _ "Main function";
+license "GPL";
 `
     };
 


### PR DESCRIPTION
Related to #9

Add predefined snippets for canonical devices in the VSCode extension.

* **src/extension.ts**
  - Add predefined snippets for step generators, encoders, PWM generators, and DACs under the `templates` object.
  - Update the `compileComp` function to include these new snippets.

* **package.json**
  - Update the `contributes` section to include new snippets for canonical devices.

* **README.md**
  - Mention the new predefined snippets for canonical devices in the features section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/linuxcnc-vscode-extension/issues/9?shareId=e2948193-b90e-44fe-8f47-4d0fb2fc8a19).