### PR TITLE
Add CI pipeline for VSCode extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+  install:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Install dependencies
+        run: npm install
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Run ESLint
+        run: npm run lint
+
+  compile:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Compile TypeScript
+        run: npm run compile
+
+  test:
+    runs-on: ubuntu-latest
+    needs: compile
+    steps:
+      - name: Run tests
+        run: npm test
+
+  package:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Package VSCode extension
+        run: npm run package
+
+  upload:
+    runs-on: ubuntu-latest
+    needs: package
+    steps:
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: vsix
+          path: '*.vsix'
+
+  version:
+    runs-on: ubuntu-latest
+    needs: upload
+    steps:
+      - name: Bump version
+        run: npm run version
+
+  changelog:
+    runs-on: ubuntu-latest
+    needs: version
+    steps:
+      - name: Generate changelog
+        run: npm run changelog

--- a/package.json
+++ b/package.json
@@ -187,12 +187,24 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install"
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "lint": "eslint . --ext .ts",
+    "test": "mocha --require ts-node/register 'src/**/*.test.ts'",
+    "package": "vsce package",
+    "version": "standard-version",
+    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },
   "devDependencies": {
     "typescript": "^4.0.3",
     "vscode": "^1.1.37",
     "@types/node": "^14.14.6",
-    "@types/vscode": "^1.50.0"
+    "@types/vscode": "^1.50.0",
+    "eslint": "^7.11.0",
+    "prettier": "^2.1.2",
+    "mocha": "^8.2.1",
+    "chai": "^4.2.0",
+    "vsce": "^1.88.0",
+    "standard-version": "^9.1.1",
+    "conventional-changelog-cli": "^2.1.1"
   }
 }


### PR DESCRIPTION
Related to #13

Add CI pipeline for VSCode extension repository using GitHub Actions.

* **package.json**:
  - Add `eslint`, `prettier`, `mocha`, `chai`, `vsce`, `standard-version`, and `conventional-changelog-cli` to `devDependencies`.
  - Add `lint`, `test`, `package`, `version`, and `changelog` scripts.

* **.github/workflows/ci.yml**:
  - Create a GitHub Actions workflow file.
  - Add job for code checkout and environment setup.
  - Add job for dependency installation.
  - Add job for code linting and formatting check.
  - Add job for TypeScript compilation.
  - Add job for unit testing.
  - Add job for VSCode extension packaging.
  - Add job for artifact upload.
  - Add job for version bumping.
  - Add job for automated changelog generation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/linuxcnc-vscode-extension/issues/13?shareId=4ff18708-840a-4fd0-9529-3bde886ffbca).