### PR TITLE
Fix CI pipeline to create bug report and attach logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,10 @@ jobs:
         run: npm run create-bugreport
         working-directory: ./
 
+      - name: Create bugreport.json file
+        run: echo '{"issue_number": 0}' > bugreport.json
+        working-directory: ./
+
       - name: Attach npm error log to GitHub issue
         run: |
           ISSUE_NUMBER=$(node -e "console.log(require('./bugreport.json').issue_number)")

--- a/create-bugreport.js
+++ b/create-bugreport.js
@@ -4,6 +4,7 @@ const { Octokit } = require('@octokit/rest');
 
 const logFilePath = path.join(__dirname, 'npm-error.log');
 const bugReportFilePath = path.join(__dirname, 'bugreport.txt');
+const bugReportJsonPath = path.join(__dirname, 'bugreport.json');
 
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
@@ -48,6 +49,13 @@ function createGitHubIssue(content) {
     body: content,
   }).then((issue) => {
     console.log('GitHub issue created successfully.');
+    fs.writeFile(bugReportJsonPath, JSON.stringify({ issue_number: issue.data.number }), 'utf8', (err) => {
+      if (err) {
+        console.error('Error writing bug report JSON file:', err);
+        return;
+      }
+      console.log('Bug report JSON file created successfully.');
+    });
     attachLogFileToIssue(issue.data.number);
   }).catch((err) => {
     console.error('Error creating GitHub issue:', err);


### PR DESCRIPTION
Related to #16

Add bug report creation and logging attachment to CI pipeline on errors.

* Modify `create-bugreport.js` to generate `bugreport.json` file containing the issue number.
* Add a step in `.github/workflows/ci.yml` to create `bugreport.json` file before attaching the npm error log.
* Modify `error-report` job in `.github/workflows/ci.yml` to include the step to create `bugreport.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/linuxcnc-vscode-extension/issues/16?shareId=c8cd9291-6809-4306-9efd-dee46d07da48).