### PR TITLE
Fix CI pipeline to create bugreport.json if it doesn't exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,15 +107,15 @@ jobs:
         run: npm install
         working-directory: ./
 
-      - name: Create bug report
-        run: npm run create-bugreport
-        working-directory: ./
-
       - name: Ensure bugreport.json is created
         run: |
           if [ ! -f ./bugreport.json ]; then
             echo '{"issue_number": 0}' > ./bugreport.json
           fi
+        working-directory: ./
+
+      - name: Create bug report
+        run: npm run create-bugreport
         working-directory: ./
 
       - name: Attach npm error log to GitHub issue

--- a/create-bugreport.js
+++ b/create-bugreport.js
@@ -64,6 +64,7 @@ function createGitHubIssue(content) {
     attachLogFileToIssue(issue.data.number);
   }).catch((err) => {
     console.error('Error creating GitHub issue:', err);
+    ensureBugReportJsonExists();
   });
 }
 
@@ -85,6 +86,18 @@ function attachLogFileToIssue(issueNumber) {
       console.error('Error attaching log file to GitHub issue:', err);
     });
   });
+}
+
+function ensureBugReportJsonExists() {
+  if (!fs.existsSync(bugReportJsonPath)) {
+    fs.writeFile(bugReportJsonPath, JSON.stringify({ issue_number: 0 }), 'utf8', (err) => {
+      if (err) {
+        console.error('Error creating bug report JSON file:', err);
+        return;
+      }
+      console.log('Bug report JSON file created successfully.');
+    });
+  }
 }
 
 createBugReport();


### PR DESCRIPTION
Related to #16

Add functionality to handle missing `bugreport.json` and ensure it is created if it doesn't exist.

* **create-bugreport.js**
  - Add `ensureBugReportJsonExists` function to create `bugreport.json` if it doesn't exist.
  - Call `ensureBugReportJsonExists` in the error handling of `createGitHubIssue`.

* **.github/workflows/ci.yml**
  - Add a step to ensure `bugreport.json` is created before running `create-bugreport.js`.
  - Reorder steps to run `create-bugreport.js` after ensuring `bugreport.json` exists.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/linuxcnc-vscode-extension/issues/16?shareId=fcb3b931-99f3-4fb2-ad1e-c5a09a0e208a).