### PR TITLE
Update Node.js version in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '18'
 
   install:
     runs-on: ubuntu-latest
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install dependencies
         run: |

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "your-publisher-name",
   "engines": {
     "vscode": "^1.50.0",
-    "node": ">=16"
+    "node": ">=18"
   },
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
Related to #16

Update Node.js version in package.json and CI pipeline configuration.

* **package.json**
  - Update the `engines.node` field to `>=18`.

* **.github/workflows/ci.yml**
  - Update the `node-version` field in the `Set up Node.js` steps to `18`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/linuxcnc-vscode-extension/issues/16?shareId=a768397d-a684-4e09-9c01-b94090ab350e).