### PR TITLE
Fix CI pipeline error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,12 @@ jobs:
           npm cache clean --force
           if [ -f package.json ]; then
             npm install
-            npm run postinstall
           else
             echo "package.json not found, skipping npm install"
           fi
+        working-directory: ./
+      - name: Run postinstall script
+        run: npm run postinstall
         working-directory: ./
       - name: Save npm error log
         if: failure()

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "postinstall": "node ./node_modules/@vscode/test-electron/install",
+    "postinstall": "node ./node_modules/@vscode/test-electron/out/install",
     "lint": "eslint . --ext .ts",
     "test": "mocha --require ts-node/register 'src/**/*.test.ts'",
     "package": "vsce package",


### PR DESCRIPTION
Related to #29

Update the `postinstall` script path and CI pipeline.

* **package.json**
  - Update the `postinstall` script to use the correct path for the `@vscode/test-electron` package.

* **.github/workflows/ci.yml**
  - Remove the `npm run postinstall` command from the `install` job.
  - Add a new step to run `npm run postinstall` after the `npm install` command in the `install` job.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/linuxcnc-vscode-extension/issues/29?shareId=18675af0-49f9-421d-b432-6ec2274ac52c).