### PR TITLE
Feature refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ This VSCode extension aims to enhance the development workflow for LinuxCNC user
 ### Pin Definition Enhancements
 - Improved Pin Definitions: Autocomplete for pin types like `bit`, `float`, `s32`, etc., ensuring valid types are used for HAL components.
 - Pin-to-parameter mapping suggestions, helping users connect pins with component parameters effectively.
+- Autocomplete suggestions for pin types such as `bit`, `float`, `s32`, and `u32`.
+- Predefined pin definition templates for common pin definitions, such as input pins, output pins, and various data types.
 
 ### Expanded Error Handling and Validation
 - Real-Time Error Checking: Real-time validation against common mistakes highlighted in the documentation, such as incorrect pin types, missing required functions (like `_update`), and misconfiguration of `addf` for real-time threads.

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -32,6 +32,19 @@
   "directives": {
     "option": {
       "settings": ["userspace", "no_auto_bind"]
+    },
+    "pin": {
+      "types": ["bit", "float", "s32", "u32"],
+      "templates": [
+        "pin in bit ${1:pin_name} \"${2:description}\";",
+        "pin out bit ${1:pin_name} \"${2:description}\";",
+        "pin in float ${1:pin_name} \"${2:description}\";",
+        "pin out float ${1:pin_name} \"${2:description}\";",
+        "pin in s32 ${1:pin_name} \"${2:description}\";",
+        "pin out s32 ${1:pin_name} \"${2:description}\";",
+        "pin in u32 ${1:pin_name} \"${2:description}\";",
+        "pin out u32 ${1:pin_name} \"${2:description}\";"
+      ]
     }
   }
 }


### PR DESCRIPTION
Related to #5

Add autocomplete suggestions and predefined templates for pin definitions.

* **language-configuration.json**
  - Add autocomplete suggestions for pin types such as `bit`, `float`, `s32`, and `u32`.
  - Add predefined pin definition templates for common pin definitions, such as input pins, output pins, and various data types.

* **README.md**
  - Update the "Pin Definition Enhancements" section to include information about the new autocomplete suggestions for pin types.
  - Update the "Pin Definition Enhancements" section to include information about the new predefined pin definition templates.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/linuxcnc-vscode-extension/issues/5?shareId=e5aee097-2f96-4c11-a2aa-6dedb9538666).