### PR TITLE
Feature refinement

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -45,6 +45,17 @@
         "pin in u32 ${1:pin_name} \"${2:description}\";",
         "pin out u32 ${1:pin_name} \"${2:description}\";"
       ]
+    },
+    "param": {
+      "types": ["float", "s32", "u32"],
+      "templates": [
+        "param rw float ${1:param_name} \"${2:description}\";",
+        "param ro float ${1:param_name} \"${2:description}\";",
+        "param rw s32 ${1:param_name} \"${2:description}\";",
+        "param ro s32 ${1:param_name} \"${2:description}\";",
+        "param rw u32 ${1:param_name} \"${2:description}\";",
+        "param ro u32 ${1:param_name} \"${2:description}\";"
+      ]
     }
   }
 }


### PR DESCRIPTION
Related to #5

Add autocomplete suggestions for parameter types under the `param` directive in `language-configuration.json`.

* **Parameter Types**:
  - Add `float`, `s32`, and `u32` to the `param` directive types.
  - Include templates for `param rw` and `param ro` for each parameter type.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/linuxcnc-vscode-extension/issues/5?shareId=3c6e3a03-1fdf-428d-a003-852bbaeba7a9).